### PR TITLE
Properly pass `$args` to index.php

### DIFF
--- a/deploy/roles/nginx/templates/nginx.conf
+++ b/deploy/roles/nginx/templates/nginx.conf
@@ -11,7 +11,7 @@ server {
 
 	location / {
 		index index.php index.html index.htm;
-		try_files $uri $uri/ /index.php$args;
+		try_files $uri $uri/ /index.php?$args;
 	}
 
 	location ~ \.php$ {


### PR DESCRIPTION
See https://github.com/humanmade/Salty-WordPress/blob/master/config/salt/config/nginx/default#L76
See #4
