### PR TITLE
Following the instructions doesn't fill the data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Then, start the VM:
 vagrant up
 ```
 
+Install the unit testing data:
+```bash
+vagrant provision
+```
+
 Finally, run this command to set "pretty permalinks" to enable the `wp-json/` route:
 
 ```bash


### PR DESCRIPTION
Following the original instructions doesn't fill in the data - a ```vagrant provision``` does seem to fill a selection of unit testing data.