### PR TITLE
Default configuration leaves Hello World post

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,4 @@ extensions:
 
 wxr:
   path: theme-unit-test-data.xml
+  clean: true


### PR DESCRIPTION
Unless the Hello World post is removed, the unit tests will fail to execute.